### PR TITLE
初始化管理员用户的时候，由判断 root 用户名是否存在改为是否有用户存在

### DIFF
--- a/utils/management/commands/inituser.py
+++ b/utils/management/commands/inituser.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             exit(1)
 
         if action == "create_super_admin":
-            if User.objects.filter(username=username).exists():
+            if User.objects.filter(id=1).exists():
                 self.stdout.write(self.style.SUCCESS(f"User {username} exists, operation ignored"))
                 exit()
 


### PR DESCRIPTION
防止 root 用户被改名之后创建重复的 root 用户的问题